### PR TITLE
Remove invalid noexcept

### DIFF
--- a/include/asbind20/invoke.hpp
+++ b/include/asbind20/invoke.hpp
@@ -323,13 +323,13 @@ public:
         return has_value();
     }
 
-    void value() noexcept
+    void value()
     {
         if(!has_value())
             throw_bad_access();
     }
 
-    void value() const noexcept
+    void value() const
     {
         if(!has_value())
             throw_bad_access();


### PR DESCRIPTION
Hello, I really like this stylish library!

By the way, while looking at the code, I noticed that `noexcept` is applied to `script_invoke_result<void>::value`, even though it may throw an exception internally.

It seems like this might be a bug, so I fixed it in this PR.