### PR TITLE
Template value class

### DIFF
--- a/doc/object_type.md
+++ b/doc/object_type.md
@@ -161,9 +161,9 @@ The template validation callback (`asBEHAVE_TEMPLATE_CALLBACK`) can be registere
 You can find detailed example in extension for registering script array.
 
 ## Notice for returning/receiving templated value class by value using generic wrapper
-Usually, the copy constructor of templated value class is declared as `(asITypeInfo*, const Class& other)`. So the class may not have a ordinary copy/move constructor in C++, thus the generic wrapper won't know how to convert them. To deal with this situation, you [need to tell asbind20 how to convert those values for generic wrapper](./custom_conv_rule.md).
-
-You can check the script optional in the extension (`ext/utility/vocabulary.hpp`) on how to return by value for generic wrapper.
+Usually, the copy constructor of templated value class is declared as `(asITypeInfo*, const Class& other)`, so the class may not have a ordinary copy/move constructor in C++, 
+thus the generic wrapper will try to use [NRVO](https://en.cppreference.com/w/cpp/language/copy_elision) for those non-copyable/non-moveable types to directly construct them at the return location.  
+However, if this is not your desired behavior, you [need to tell asbind20 how to convert those values for generic wrapper](./custom_conv_rule.md).
 
 # Registering an Interface
 ```c++

--- a/doc/object_type.md
+++ b/doc/object_type.md
@@ -59,6 +59,8 @@ asbind20::value_class<my_value_class>(...)
     .method("void do_something(my_value_class& other)", &do_something, asbind20::call_conv<asCALL_CDECL_OBJLAST>);
 ```
 
+3. If you want to register a templated value class, please read the following sections.
+
 ## Generating Wrappers
 asbind20 has support for generating wrappers for common usage.
 
@@ -151,12 +153,17 @@ For non-template reference class, register it with `ref_class` helper. This is s
 
 Besides, the generated operator wrappers don't support function that may return a reference class by value, e.g. `T opAdd(const T&in) const`.
 
-## Template Class
-The template class is a special reference class. It can be registered with `template_class`. The binding generator will automatically handle the hidden type information (passed by `int&in` in AngelScript) as the first argument when generating factory function from constructors.
+# Templated Value/Reference Class
+The template class is special value/reference class. It can be registered with `template_value_class`/`template_ref_class`. The binding generator will automatically handle the hidden type information (`asITypeInfo*`, passed by `int&in` in AngelScript) as the first argument when generating constructor/factory function from C++ constructors.
 
-The template validation callback (`asBEHAVE_TEMPLATE_CALLBACK`) can be registered with `template_callback`. The C++ signature of the callback should be either `bool(asITypeInfo*, bool&)` or `bool(asITypeInfo*, bool*)`.
+The template validation callback (`asBEHAVE_TEMPLATE_CALLBACK`) can be registered with `template_callback`. The C++ signature of the callback should be `bool(asITypeInfo*, bool&)`. You can read the [official document explaining template callback](https://www.angelcode.com/angelscript/sdk/docs/manual/doc_adv_template.html#doc_adv_template_4).
 
 You can find detailed example in extension for registering script array.
+
+## Notice for returning/receiving templated value class by value using generic wrapper
+Usually, the copy constructor of templated value class is declared as `(asITypeInfo*, const Class& other)`. So the class may not have a ordinary copy/move constructor in C++, thus the generic wrapper won't know how to convert them. To deal with this situation, you [need to tell asbind20 how to convert those values for generic wrapper](./custom_conv_rule.md).
+
+You can check the script optional in the extension (`ext/utility/vocabulary.hpp`) on how to return by value for generic wrapper.
 
 # Registering an Interface
 ```c++

--- a/ext/container/include/asbind20/ext/array.hpp
+++ b/ext/container/include/asbind20/ext/array.hpp
@@ -118,7 +118,7 @@ public:
 
     size_type count(const void* value, size_type idx = 0, size_type n = -1) const;
 
-    script_optional* find_optional(const void* val, size_type idx = 0);
+    script_optional find_optional(const void* val, size_type idx = 0);
 
     [[nodiscard]]
     asITypeInfo* script_type_info() const noexcept

--- a/ext/utility/include/asbind20/ext/vocabulary.hpp
+++ b/ext/utility/include/asbind20/ext/vocabulary.hpp
@@ -61,6 +61,9 @@ public:
         return m_ti;
     }
 
+    void enum_refs(asIScriptEngine* engine);
+    void release_refs(asIScriptEngine* engine);
+
 private:
     asITypeInfo* m_ti = nullptr;
 

--- a/ext/utility/include/asbind20/ext/vocabulary.hpp
+++ b/ext/utility/include/asbind20/ext/vocabulary.hpp
@@ -62,22 +62,6 @@ public:
     }
 
 private:
-    friend type_traits<script_optional>;
-
-    // For generic calling convention
-    void move_to_ret_loc(void* dst)
-    {
-        new(dst) script_optional(m_ti);
-
-        script_optional* opt = static_cast<script_optional*>(dst);
-        if(m_has_value)
-        {
-            opt->m_has_value = true;
-            std::memcpy(&opt->m_data, &m_data, sizeof(m_data));
-            m_has_value = false;
-        }
-    }
-
     asITypeInfo* m_ti = nullptr;
 
     union data_t
@@ -102,17 +86,5 @@ private:
     void release();
 };
 } // namespace asbind20::ext
-
-template <>
-struct asbind20::type_traits<asbind20::ext::script_optional>
-{
-    static int set_return(
-        AS_NAMESPACE_QUALIFIER asIScriptGeneric* gen, ext::script_optional&& val
-    )
-    {
-        val.move_to_ret_loc(gen->GetAddressOfReturnLocation());
-        return AS_NAMESPACE_QUALIFIER asSUCCESS;
-    }
-};
 
 #endif

--- a/include/asbind20/generic.hpp
+++ b/include/asbind20/generic.hpp
@@ -258,6 +258,9 @@ void set_generic_return(
 /**
  * @brief Set generic return value by invocation result
  *
+ * @note Use this function instead of directly using the `set_generic_return` for non-moveable types.
+ *       This function will try to use NRVO for non-moveable types.
+ *
  * @tparam Return Return type
  *
  * @param fn Function to invoke
@@ -269,9 +272,23 @@ void set_generic_return_by(
     Args&&... args
 )
 {
+    constexpr bool is_customized = requires() {
+        { type_traits<std::remove_cv_t<Return>>::set_return(gen, std::declval<Return>()) } -> std::same_as<int>;
+    };
+    constexpr bool non_moveable =
+        !(std::is_reference_v<Return> || std::is_pointer_v<Return>) &&
+        std::is_class_v<Return> &&
+        (!is_customized ||
+         std::is_move_constructible_v<Return>);
+
     if constexpr(std::is_void_v<Return>)
     {
         std::invoke(std::forward<Fn>(fn), std::forward<Args>(args)...);
+    }
+    else if constexpr(non_moveable) // Try NRVO for non-moveable types
+    {
+        void* mem = gen->GetAddressOfReturnLocation();
+        new(mem) Return(std::invoke(std::forward<Fn>(fn), std::forward<Args>(args)...));
     }
     else
     {

--- a/include/asbind20/generic.hpp
+++ b/include/asbind20/generic.hpp
@@ -213,8 +213,15 @@ void set_generic_return(
     }
     else if constexpr(std::is_class_v<Return>)
     {
-        void* mem = gen->GetAddressOfReturnLocation();
-        new(mem) Return(std::forward<Return>(ret));
+        if constexpr(is_only_constructible_v<Return, Return&&>)
+        {
+            void* mem = gen->GetAddressOfReturnLocation();
+            new(mem) Return(std::forward<Return>(ret));
+        }
+        else
+        {
+            gen->SetReturnObject((void*)std::addressof(ret));
+        }
     }
     else if constexpr(std::is_enum_v<Return>)
     {

--- a/test/test_bind/template_value_class.cpp
+++ b/test/test_bind/template_value_class.cpp
@@ -12,6 +12,9 @@ public:
     template_val(AS_NAMESPACE_QUALIFIER asITypeInfo* ti)
         : subtype_id(ti->GetSubTypeId()) {}
 
+    template_val(AS_NAMESPACE_QUALIFIER asITypeInfo* ti, const template_val& val)
+        : subtype_id(ti->GetSubTypeId()), value(val.value) {}
+
     template_val(AS_NAMESPACE_QUALIFIER asITypeInfo* ti, int val)
         : subtype_id(ti->GetSubTypeId()), value(val) {}
 
@@ -44,15 +47,18 @@ static void register_template_val_class(AS_NAMESPACE_QUALIFIER asIScriptEngine* 
         new(mem) template_val(ti, val1 * 100 + val2);
     };
 
+    constexpr AS_NAMESPACE_QUALIFIER asQWORD flags =
+        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_CDA |
+        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_ALLINTS |
+        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_MORE_CONSTRUCTORS;
     template_value_class<template_val>(
         engine,
         "template_val<T>",
-        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_CD |
-            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_ALLINTS |
-            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_MORE_CONSTRUCTORS
+        flags
     )
         .template_callback(template_callback)
         .default_constructor()
+        .opAssign()
         .constructor_function("int", use_explicit, &create_template_val)
         .constructor_function("int,int", wrapper)
         .destructor()

--- a/test/test_bind/template_value_class.cpp
+++ b/test/test_bind/template_value_class.cpp
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+#include <shared_test_lib.hpp>
+#include <asbind20/asbind.hpp>
+
+namespace test_bind
+{
+class template_val
+{
+public:
+    template_val() = delete;
+
+    template_val(AS_NAMESPACE_QUALIFIER asITypeInfo* ti)
+        : subtype_id(ti->GetSubTypeId()) {}
+
+    template_val(AS_NAMESPACE_QUALIFIER asITypeInfo* ti, int val)
+        : subtype_id(ti->GetSubTypeId()), value(val) {}
+
+    ~template_val() = default;
+
+    int subtype_id;
+    int value = 0;
+};
+
+static bool template_callback(AS_NAMESPACE_QUALIFIER asITypeInfo* ti, bool& no_gc)
+{
+    no_gc = true;
+
+    int subtype_id = ti->GetSubTypeId();
+    return subtype_id == AS_NAMESPACE_QUALIFIER asTYPEID_INT32 ||
+           subtype_id == AS_NAMESPACE_QUALIFIER asTYPEID_FLOAT;
+}
+
+static void create_template_val(void* mem, AS_NAMESPACE_QUALIFIER asITypeInfo* ti, int val)
+{
+    new(mem) template_val(ti, val);
+}
+
+static void register_template_val_class(AS_NAMESPACE_QUALIFIER asIScriptEngine* engine)
+{
+    using namespace asbind20;
+
+    auto wrapper = [](AS_NAMESPACE_QUALIFIER asITypeInfo* ti, int val1, int val2, void* mem) -> void
+    {
+        new(mem) template_val(ti, val1 * 100 + val2);
+    };
+
+    template_value_class<template_val>(
+        engine,
+        "template_val<T>",
+        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_CD |
+            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_ALLINTS |
+            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_MORE_CONSTRUCTORS
+    )
+        .template_callback(template_callback)
+        .default_constructor()
+        .constructor_function("int", use_explicit, &create_template_val)
+        .constructor_function("int,int", wrapper)
+        .destructor()
+        .property("int subtype_id", &template_val::subtype_id)
+        .property("int value", &template_val::value);
+}
+
+static void register_template_val_class(asbind20::use_generic_t, AS_NAMESPACE_QUALIFIER asIScriptEngine* engine)
+{
+    using namespace asbind20;
+
+    auto wrapper = [](AS_NAMESPACE_QUALIFIER asITypeInfo* ti, int val1, int val2, void* mem) -> void
+    {
+        new(mem) template_val(ti, val1 * 100 + val2);
+    };
+
+    template_value_class<template_val, true>(
+        engine,
+        "template_val<T>",
+        AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_CD |
+            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_ALLINTS |
+            AS_NAMESPACE_QUALIFIER asOBJ_APP_CLASS_MORE_CONSTRUCTORS
+    )
+        .template_callback(fp<&template_callback>)
+        .default_constructor()
+        .constructor_function("int", use_explicit, fp<&create_template_val>)
+        .constructor_function("int,int", wrapper)
+        .destructor()
+        .property("int subtype_id", &template_val::subtype_id)
+        .property("int value", &template_val::value);
+}
+} // namespace test_bind
+
+using asbind_test::asbind_test_suite;
+using asbind_test::asbind_test_suite_generic;
+
+const char* template_value_class_test_script = R"(
+int test_0()
+{
+    template_val<int> val;
+    return val.subtype_id;
+}
+int test_1()
+{
+    template_val<float> val;
+    return val.subtype_id;
+}
+int test_2()
+{
+    template_val<int> val(42);
+    assert(val.value == 42);
+    return val.subtype_id;
+}
+int test_3()
+{
+    template_val<float> val(10, 13);
+    assert(val.value == 1013);
+    return val.subtype_id;
+})";
+
+static void check_template_val_class(AS_NAMESPACE_QUALIFIER asIScriptEngine* engine)
+{
+    auto* m = engine->GetModule("test_template_value_class", AS_NAMESPACE_QUALIFIER asGM_ALWAYS_CREATE);
+    ASSERT_TRUE(m);
+
+    m->AddScriptSection(
+        "test_template_value_class.as",
+        template_value_class_test_script
+    );
+    ASSERT_GE(m->Build(), 0);
+
+    auto check_int_result = [&](int idx, int expected_val) -> void
+    {
+        std::string test_name = asbind20::string_concat("test_", std::to_string(idx));
+        auto test_case = asbind20::script_function<int()>(m->GetFunctionByName(test_name.c_str()));
+
+        asbind20::request_context ctx(engine);
+        auto result = test_case(ctx);
+
+        using asbind_test::result_has_value;
+        ASSERT_TRUE(result_has_value(result));
+        EXPECT_EQ(*result, expected_val)
+            << test_name;
+    };
+
+    check_int_result(0, AS_NAMESPACE_QUALIFIER asTYPEID_INT32);
+    check_int_result(1, AS_NAMESPACE_QUALIFIER asTYPEID_FLOAT);
+    check_int_result(2, AS_NAMESPACE_QUALIFIER asTYPEID_INT32);
+    check_int_result(3, AS_NAMESPACE_QUALIFIER asTYPEID_FLOAT);
+}
+
+TEST_F(asbind_test_suite, template_val_class)
+{
+    if(asbind20::has_max_portability())
+        GTEST_SKIP() << "AS_MAX_PORTABILITY";
+
+    auto* engine = get_engine();
+
+    test_bind::register_template_val_class(engine);
+    check_template_val_class(engine);
+}
+
+TEST_F(asbind_test_suite_generic, template_val_class)
+{
+    auto* engine = get_engine();
+
+    test_bind::register_template_val_class(asbind20::use_generic, engine);
+    check_template_val_class(engine);
+}


### PR DESCRIPTION
1. Now support templated value class.
2. Generic wrapper now can use NRVO for handling non-copyable/non-moveable types.
3. Update the `script_optional` from extension library for demonstrating template value class.
4. GC behaviors support for value type.
5. Documentation