### PR TITLE
Class Inheritance

### DIFF
--- a/include/asbind20/bind/class.hpp
+++ b/include/asbind20/bind/class.hpp
@@ -1118,7 +1118,7 @@ namespace detail
     };
     
     /** 
-    // Metadata Tracking for Automatic Inheritance
+     * Metadata Tracking for Automatic Inheritance
     */ 
     
     // Metadata for a registered method
@@ -1186,16 +1186,39 @@ inline void clear_inheritance_metadata()
     detail::get_property_registry().clear();
 }
 
-// Helper function for reference casting between types in inheritance hierarchy
+/**
+ * @brief Helper function for reference casting between types in inheritance hierarchy
+ * 
+ * This function enables implicit upcasting in AngelScript when using .base<>() inheritance.
+ * It uses dynamic_cast for safe runtime type conversion.
+ * 
+ * @tparam From Source type (derived class)
+ * @tparam To Target type (base class)
+ * @param from Pointer to source object
+ * @return Pointer to target type, or nullptr if cast fails
+ * 
+ * @warning CRITICAL REQUIREMENTS:
+ * 1. RTTI (Run-Time Type Information) MUST be enabled in compiler settings
+ *    - MSVC: /GR (enabled by default)
+ *    - GCC/Clang: -frtti (enabled by default)
+ * 
+ * 2. C++ classes in the inheritance hierarchy MUST be polymorphic
+ *    - At least ONE virtual function is required (typically a virtual destructor)
+ *    - Example: virtual ~CBaseEntity() = default;
+ * 
+ * @note Without RTTI or virtual functions, dynamic_cast will fail to compile
+ *       or produce incorrect results, breaking the inheritance system.
+ * 
+ * @note The handle reference will be managed by AngelScript - no manual addref needed.
+ */
 template<typename From, typename To>
 To* asbind20_refCast(From* from)
 {
     if (!from) return nullptr;
     
-    // Try to cast using dynamic_cast
+    // Use dynamic_cast for safe runtime type conversion
+    // This requires RTTI and polymorphic classes (see warning above)
     To* to = dynamic_cast<To*>(from);
-    // If cast succeeds, the handle reference will be managed by AngelScript
-    // No need to manually call addref here as AngelScript handles it
     return to;
 }
 


### PR DESCRIPTION
Should allow for full property and method inheritance. 
Everything below base() will receive inherited property/method access. 
Everything above it will overwrite the derived method/property.

Unsure if this is even wanted, but I got tired of rewriting methods for classes that were inherited C++ side.
I have to call `asbind20::clear_inheritance_metadata();` every AngelScript engine re-initialization. I'm sure there's a better way to handle that.

EDIT: forgot to add examples:
```cpp
// Step 1: Register the BASE class first
void RegisterCBaseEntity(asIScriptEngine* pEngine)
{
    asbind20::ref_class<CBaseEntity>(pEngine, "CBaseEntity")
        .addref(&AddRef_CBaseEntity)
        .release(&Release_CBaseEntity)
        // Base class methods
        .method("void SetOrigin(const Vector3 &in)", &CBaseEntity::SetOrigin)
        .method("Vector3 GetOrigin() const", &CBaseEntity::GetOrigin)
        .method("bool IsAlive()", &CBaseEntity::IsAlive)
        // Base class properties
        .property("int pev_health", &CBaseEntity::pev->health);
}

// Step 2: Register the DERIVED class and call .base<>()
void RegisterCBaseMonster(asIScriptEngine* pEngine)
{
    asbind20::ref_class<CBaseMonster>(pEngine, "CBaseMonster")
        .addref(&AddRef_CBaseMonster)
        .release(&Release_CBaseMonster)
        // Derived class methods
        .method("int BloodColor()", &CBaseMonster::BloodColor)
        .method("void Look(int)", &CBaseMonster::Look)
        // Derived class properties
        .property("float m_flFieldOfView", &CBaseMonster::m_flFieldOfView)
        
        // IMPORTANT: Call .base<>() LAST to inherit everything from CBaseEntity
        .base<CBaseEntity>();
}

// Step 3: Register types in correct order
void RegisterAll(asIScriptEngine* pEngine)
{
    RegisterCBaseEntity(pEngine);    // Base FIRST
    RegisterCBaseMonster(pEngine);   // Derived SECOND
}
```
